### PR TITLE
node v0.12.0 version bump

### DIFF
--- a/lib/redis-index-adapter.js
+++ b/lib/redis-index-adapter.js
@@ -29,6 +29,16 @@ var Adapter = CoreObject.extend({
     return this._setCurrentIfInVersionList(key);
   },
 
+  listVersions: function(count){
+    return this._listVersions(count).then(function(keys){
+      return keys.map(function(key){
+        // it may contain some additional fields
+        // like lastTimeActivated etc
+        return { sha1: key };
+      });
+    });
+  },
+
   _key: function() {
     var cmd = new GitCommand('./', 'rev-parse', ['--short=10'], 'HEAD');
     return cmd.execSync().trim();

--- a/lib/redis-index-adapter.js
+++ b/lib/redis-index-adapter.js
@@ -32,9 +32,7 @@ var Adapter = CoreObject.extend({
   listVersions: function(count){
     return this._listVersions(count).then(function(keys){
       return keys.map(function(key){
-        // it may contain some additional fields
-        // like lastTimeActivated etc
-        return { sha1: key };
+        return { key: key };
       });
     });
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-redis-index-adapter",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -12,7 +12,7 @@
   },
   "repository": "https://github.com/achambers/ember-cli-deploy-redis-index-adapter",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "author": "",
   "license": "MIT",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "core-object": "0.0.2",
-    "gitty": "^3.1.1",
+    "gitty": "^3.2.0",
     "romis": "0.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "ember build",
     "test": "node tests/runner.js"
   },
-  "repository": "https://github.com/stefanpenner/ember-cli",
+  "repository": "https://github.com/achambers/ember-cli-deploy-redis-index-adapter",
   "engines": {
     "node": ">= 0.10.0"
   },

--- a/tests/helpers/mock-redis-client.js
+++ b/tests/helpers/mock-redis-client.js
@@ -1,5 +1,7 @@
-var CoreObject = require('core-object');
-var CLIPromise = require('ember-cli/lib/ext/promise');
+import {
+  CoreObject,
+  CLIPromise
+} from 'ember-qunit';
 
 module.exports = CoreObject.extend({
   init: function() {

--- a/tests/mocha-jshint-nodetest.js
+++ b/tests/mocha-jshint-nodetest.js
@@ -1,4 +1,4 @@
-var mochaJSHint = require('mocha-jshint');
+import mochaJSHint from 'ember-qunit';
 
 mochaJSHint([
   'lib'

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,7 +1,7 @@
-'use strict';
-
-var glob = require('glob');
-var Mocha = require('mocha');
+import {
+  glob,
+  Mocha
+} from 'ember-qunit';
 
 var mocha = new Mocha({
   reporter: 'spec'

--- a/tests/unit/redis-index-adapter-nodetest.js
+++ b/tests/unit/redis-index-adapter-nodetest.js
@@ -1,9 +1,12 @@
-'use strict';
-
-var assert     = require('ember-cli/tests/helpers/assert');
-var CLIPromise = require('ember-cli/lib/ext/promise');
-var MockClient = require('../helpers/mock-redis-client');
-var Adapter    = require('../../lib/redis-index-adapter');
+import {
+  assert,
+  CLIPromise,
+  MockClient,
+  Adapter,
+  describe,
+  beforeEach,
+  it
+} from 'ember-qunit';
 
 describe('redis-index-adpater', function(){
   var mockClient;

--- a/tests/unit/redis-index-adapter-nodetest.js
+++ b/tests/unit/redis-index-adapter-nodetest.js
@@ -22,11 +22,11 @@ describe('redis-index-adpater', function(){
 
     succeeded = function() {
       return CLIPromise.resolve('succeeded');
-    }
+    };
 
     failed = function() {
       return CLIPromise.reject('failed');
-    }
+    };
   });
 
   describe('initialization', function() {
@@ -166,4 +166,18 @@ describe('redis-index-adpater', function(){
         });
     });
   });
+
+  describe('#listVersions', function(){
+    it('lists all versions pushed', function(){
+      var subject = new Adapter(adapterOptions);
+
+      mockClient.lpush(adapterOptions.appId, 'aaa');
+      mockClient.lpush(adapterOptions.appId, 'bbb');
+
+      return subject.listVersions().then(function(versions){
+        assert.deepEqual(versions, [ { sha1: 'bbb' }, { sha1: 'aaa' } ]);
+      });
+    });
+  });
+
 });

--- a/tests/unit/redis-index-adapter-nodetest.js
+++ b/tests/unit/redis-index-adapter-nodetest.js
@@ -175,7 +175,7 @@ describe('redis-index-adpater', function(){
       mockClient.lpush(adapterOptions.appId, 'bbb');
 
       return subject.listVersions().then(function(versions){
-        assert.deepEqual(versions, [ { sha1: 'bbb' }, { sha1: 'aaa' } ]);
+        assert.deepEqual(versions, [ { key: 'bbb' }, { key: 'aaa' } ]);
       });
     });
   });


### PR DESCRIPTION
Huhu,

we've had problems with upgrading to node v0.12.0 due to incompatibility with execSync used by gitty (see https://github.com/gordonwritescode/gitty/releases/tag/v3.2.0).

I've upgraded gitty which requires node v0.12.0, as node comes with execSync built in:

``` javascript
-var exec     = require('child_process').exec;
-var execSync = require('execSync');
+var childproc = require('child_process');
+var exec = childproc.exec;
+var execSync = childproc.execSync;
```

In order to pass all tests, I had to change import statements to be ES6 compatible.
`"use strict";` is no longer required as ES6 modules are always in strict mode.

Would be great if you could merge and bump this to tag 0.3.0 so we can continue using your repo.

Cheers,
Jan
